### PR TITLE
[HIPIFY][perception][base] The rest of `base` files are hipified

### DIFF
--- a/modules/perception/base/blob_test.cc
+++ b/modules/perception/base/blob_test.cc
@@ -71,6 +71,10 @@ namespace apollo {
 namespace perception {
 namespace base {
 
+#if GPU_PLATFORM == AMD
+  #define cudaMalloc hipMalloc
+#endif
+
 TEST(BlobTest, header_test) {
   Blob<float> blob_empty;
   EXPECT_EQ(blob_empty.shape_string(), "(0)");

--- a/modules/perception/base/common_test.cc
+++ b/modules/perception/base/common_test.cc
@@ -21,6 +21,10 @@ namespace apollo {
 namespace perception {
 namespace base {
 
+#if GPU_PLATFORM == AMD
+  #define cudaSetDevice hipSetDevice
+#endif
+
 TEST(CommonTest, GPUAssertTest) {
 #if USE_GPU == 1
   GPUAssert(cudaSetDevice(-1), __FILE__, __LINE__, false);

--- a/modules/perception/base/syncedmem.cc
+++ b/modules/perception/base/syncedmem.cc
@@ -66,6 +66,21 @@ namespace apollo {
 namespace perception {
 namespace base {
 
+#if GPU_PLATFORM == AMD
+  #define cudaGetDevice hipGetDevice
+  #define cudaFree hipFree
+  #define cudaMemcpy hipMemcpy
+  #define cudaMemcpyDefault hipMemcpyDefault
+  #define cudaMalloc hipMalloc
+  #define cudaMemset hipMemset
+  #define cudaStream_t hipStream_t
+  #define cudaMemcpyKind hipMemcpyKind
+  #define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+  #define cudaMemcpyAsync hipMemcpyAsync
+  #define cudaPointerAttributes hipPointerAttribute_t
+  #define cudaPointerGetAttributes hipPointerGetAttributes
+#endif
+
 SyncedMemory::SyncedMemory(bool use_cuda)
     : cpu_ptr_(NULL),
       gpu_ptr_(NULL),

--- a/modules/perception/base/syncedmem_test.cc
+++ b/modules/perception/base/syncedmem_test.cc
@@ -147,6 +147,12 @@ TEST_F(SyncedMemoryTest, TestCPUWrite) {
 
 #if USE_GPU == 1  // GPU test
 
+#if GPU_PLATFORM == AMD
+  #define cudaMemcpy hipMemcpy
+  #define cudaMemcpyDefault hipMemcpyDefault
+  #define cudaMemset hipMemset
+#endif
+
 TEST_F(SyncedMemoryTest, TestGPURead) {
   SyncedMemory mem(10, true);
   void* cpu_data = mem.mutable_cpu_data();


### PR DESCRIPTION
+ [ToDo]: hipify `Eigen` only
+ [IMP] `cudaPointerGetAttributes` is experimentally supported in ROCm HIP 5.0
