### PR TITLE
[HIPIFY][perception][inference][fix] Refactor: move hipfication macros to common header files where it is possible

### DIFF
--- a/modules/perception/inference/caffe/caffe_net.cc
+++ b/modules/perception/inference/caffe/caffe_net.cc
@@ -22,11 +22,6 @@ namespace apollo {
 namespace perception {
 namespace inference {
 
-#if GPU_PLATFORM == AMD
-  #define cudaMemcpy hipMemcpy
-  #define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
-#endif
-
 CaffeNet::CaffeNet(const std::string &net_file, const std::string &model_file,
                    const std::vector<std::string> &outputs)
     : net_file_(net_file), model_file_(model_file), output_names_(outputs) {}

--- a/modules/perception/inference/onnx/onnx_obstacle_detector.cc
+++ b/modules/perception/inference/onnx/onnx_obstacle_detector.cc
@@ -16,11 +16,6 @@
 
 #include "modules/perception/inference/onnx/onnx_obstacle_detector.h"
 
-#if GPU_PLATFORM == NVIDIA
-  #include <cuda_runtime_api.h>
-#elif GPU_PLATFORM == AMD
-  #include <hip/hip_runtime_api.h>
-#endif
 #include "cyber/common/log.h"
 
 namespace apollo {
@@ -28,23 +23,6 @@ namespace perception {
 namespace inference {
 
 using apollo::perception::base::Blob;
-
-#if GPU_PLATFORM == AMD
-  #define cudaError_t hipError_t
-  #define cudaSuccess hipSuccess
-  #define cudaGetErrorString hipGetErrorString
-#endif
-
-#define GPU_CHECK(ans) \
-  { GPUAssert((ans), __FILE__, __LINE__); }
-inline void GPUAssert(cudaError_t code, const char* file, int line,
-                      bool abort = true) {
-  if (code != cudaSuccess) {
-    fprintf(stderr, "GPUassert: %s %s %d\n", cudaGetErrorString(code), file,
-            line);
-    if (abort) exit(code);
-  }
-}
 
 OnnxObstacleDetector::OnnxObstacleDetector(
   const std::string &model_file,

--- a/modules/perception/inference/tensorrt/plugins/argmax_plugin.h
+++ b/modules/perception/inference/tensorrt/plugins/argmax_plugin.h
@@ -26,10 +26,6 @@ namespace apollo {
 namespace perception {
 namespace inference {
 
-#if GPU_PLATFORM == AMD
-  #define cudaStream_t hipStream_t
-#endif
-
 class ArgMax1Plugin : public nvinfer1::IPlugin {
  public:
   ArgMax1Plugin(const ArgMaxParameter &argmax_param, nvinfer1::Dims in_dims)


### PR DESCRIPTION
+ Hipification is in modules\perception\base\common.h
+ onnx_obstacle_detector.cc: CUDA dead code is eliminated with the corresponding CUDA includes
