### PR TITLE
[HIPIFY][perception][camera][refactor] Remove hipification code

### DIFF
--- a/modules/perception/camera/common/data_provider.cc
+++ b/modules/perception/camera/common/data_provider.cc
@@ -25,13 +25,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaSetDevice hipSetDevice
-  #define cudaSuccess hipSuccess
-  #define cudaMemcpy hipMemcpy
-  #define cudaMemcpyDefault hipMemcpyDefault
-#endif
-
 bool DataProvider::Init(const DataProvider::InitOptions &options) {
   src_height_ = options.image_height;
   src_width_ = options.image_width;

--- a/modules/perception/camera/common/undistortion_handler.cc
+++ b/modules/perception/camera/common/undistortion_handler.cc
@@ -30,12 +30,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaSetDevice hipSetDevice
-  #define cudaSuccess hipSuccess
-  #define cudaGetErrorString hipGetErrorString
-#endif
-
 bool UndistortionHandler::set_device(int device) {
   device_ = device;
   auto code = cudaSetDevice(device_);

--- a/modules/perception/camera/lib/feature_extractor/tfe/project_feature.cc
+++ b/modules/perception/camera/lib/feature_extractor/tfe/project_feature.cc
@@ -30,12 +30,6 @@ namespace camera {
 
 using cyber::common::GetAbsolutePath;
 
-#if GPU_PLATFORM == AMD
-  #define cudaMemcpy hipMemcpy
-  #define cudaMemcpyDefault hipMemcpyDefault
-  #define cudaDeviceSynchronize hipDeviceSynchronize
-#endif
-
 bool ProjectFeature::Init(const FeatureExtractorInitOptions &options) {
   std::string efx_config = GetAbsolutePath(options.root_dir, options.conf_file);
   ACHECK(cyber::common::GetProtoFromFile(efx_config, &param_))

--- a/modules/perception/camera/lib/lane/detector/darkSCNN/darkSCNN_lane_detector.cc
+++ b/modules/perception/camera/lib/lane/detector/darkSCNN/darkSCNN_lane_detector.cc
@@ -31,12 +31,6 @@ namespace camera {
 using apollo::cyber::common::GetAbsolutePath;
 using apollo::cyber::common::GetProtoFromFile;
 
-#if GPU_PLATFORM == AMD
-  #define cudaDeviceProp hipDeviceProp_t
-  #define cudaGetDeviceProperties hipGetDeviceProperties
-  #define cudaDeviceSynchronize hipDeviceSynchronize
-#endif
-
 bool DarkSCNNLaneDetector::Init(const LaneDetectorInitOptions &options) {
   std::string proto_path = GetAbsolutePath(options.root_dir, options.conf_file);
   if (!GetProtoFromFile(proto_path, &darkscnn_param_)) {

--- a/modules/perception/camera/lib/lane/detector/denseline/denseline_lane_detector.cc
+++ b/modules/perception/camera/lib/lane/detector/denseline/denseline_lane_detector.cc
@@ -29,12 +29,6 @@ namespace camera {
 
 using cyber::common::GetAbsolutePath;
 
-#if GPU_PLATFORM == AMD
-  #define cudaDeviceProp hipDeviceProp_t
-  #define cudaGetDeviceProperties hipGetDeviceProperties
-  #define cudaDeviceSynchronize hipDeviceSynchronize
-#endif
-
 bool DenselineLaneDetector::Init(const LaneDetectorInitOptions &options) {
   std::string proto_path = GetAbsolutePath(options.root_dir, options.conf_file);
   if (!cyber::common::GetProtoFromFile(proto_path, &denseline_param_)) {

--- a/modules/perception/camera/lib/obstacle/detector/smoke/smoke_obstacle_detector.cc
+++ b/modules/perception/camera/lib/obstacle/detector/smoke/smoke_obstacle_detector.cc
@@ -30,12 +30,6 @@ namespace camera {
 
 using cyber::common::GetAbsolutePath;
 
-#if GPU_PLATFORM == AMD
-  #define cudaSetDevice hipSetDevice
-  #define cudaStreamCreate hipStreamCreate
-  #define cudaSuccess hipSuccess
-#endif
-
 void SmokeObstacleDetector::LoadInputShape(
                             const smoke::ModelParam &model_param) {
   float offset_ratio = model_param.offset_ratio();

--- a/modules/perception/camera/lib/obstacle/detector/smoke/smoke_obstacle_detector.h
+++ b/modules/perception/camera/lib/obstacle/detector/smoke/smoke_obstacle_detector.h
@@ -38,11 +38,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaStreamDestroy hipStreamDestroy
-  #define cudaStream_t hipStream_t
-#endif
-
 class SmokeObstacleDetector : public BaseObstacleDetector {
  public:
   SmokeObstacleDetector() : BaseObstacleDetector() {}

--- a/modules/perception/camera/lib/obstacle/detector/yolo/region_output.cc
+++ b/modules/perception/camera/lib/obstacle/detector/yolo/region_output.cc
@@ -23,10 +23,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaStream_t hipStream_t
-#endif
-
 void get_intersect_bbox(const NormalizedBBox &bbox1,
                         const NormalizedBBox &bbox2,
                         NormalizedBBox *intersect_bbox) {

--- a/modules/perception/camera/lib/obstacle/detector/yolo/region_output.cu
+++ b/modules/perception/camera/lib/obstacle/detector/yolo/region_output.cu
@@ -32,11 +32,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaStream_t hipStream_t
-  #define cudaStreamSynchronize hipStreamSynchronize
-#endif
-
 __host__ __device__ float sigmoid_gpu(float x) { return 1.0 / (1.0 + exp(-x)); }
 
 __host__ __device__ float bbox_size_gpu(const float *bbox,

--- a/modules/perception/camera/lib/obstacle/detector/yolo/region_output.h
+++ b/modules/perception/camera/lib/obstacle/detector/yolo/region_output.h
@@ -35,10 +35,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaStream_t hipStream_t
-#endif
-
 static const char NormalNMS[] = "NormalNMS";
 static const char LinearSoftNMS[] = "LinearSoftNMS";
 static const char GuassianSoftNMS[] = "GuassianSoftNMS";

--- a/modules/perception/camera/lib/obstacle/detector/yolo/yolo_obstacle_detector.cc
+++ b/modules/perception/camera/lib/obstacle/detector/yolo/yolo_obstacle_detector.cc
@@ -30,12 +30,6 @@ namespace camera {
 
 using cyber::common::GetAbsolutePath;
 
-#if GPU_PLATFORM == AMD
-  #define cudaSetDevice hipSetDevice
-  #define cudaStreamCreate hipStreamCreate
-  #define cudaSuccess hipSuccess
-#endif
-
 void YoloObstacleDetector::LoadInputShape(const yolo::ModelParam &model_param) {
   float offset_ratio = model_param.offset_ratio();
   float cropped_ratio = model_param.cropped_ratio();

--- a/modules/perception/camera/lib/obstacle/detector/yolo/yolo_obstacle_detector.h
+++ b/modules/perception/camera/lib/obstacle/detector/yolo/yolo_obstacle_detector.h
@@ -37,11 +37,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaStreamDestroy hipStreamDestroy
-  #define cudaStream_t hipStream_t
-#endif
-
 class YoloObstacleDetector : public BaseObstacleDetector {
  public:
   YoloObstacleDetector() : BaseObstacleDetector() {}

--- a/modules/perception/camera/lib/obstacle/detector/yolov4/region_output.cu
+++ b/modules/perception/camera/lib/obstacle/detector/yolov4/region_output.cu
@@ -31,11 +31,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaStream_t hipStream_t
-  #define cudaStreamSynchronize hipStreamSynchronize
-#endif
-
 __host__ __device__ float sigmoid_gpu(float x) { return 1.0 / (1.0 + exp(-x)); }
 
 __host__ __device__ float bbox_size_gpu(const float *bbox,

--- a/modules/perception/camera/lib/obstacle/detector/yolov4/region_output.h
+++ b/modules/perception/camera/lib/obstacle/detector/yolov4/region_output.h
@@ -34,10 +34,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaStream_t hipStream_t
-#endif
-
 static const char NormalNMS[] = "NormalNMS";
 static const char LinearSoftNMS[] = "LinearSoftNMS";
 static const char GuassianSoftNMS[] = "GuassianSoftNMS";

--- a/modules/perception/camera/lib/obstacle/detector/yolov4/yolov4_obstacle_detector.cc
+++ b/modules/perception/camera/lib/obstacle/detector/yolov4/yolov4_obstacle_detector.cc
@@ -30,12 +30,6 @@ namespace camera {
 
 using cyber::common::GetAbsolutePath;
 
-#if GPU_PLATFORM == AMD
-  #define cudaSetDevice hipSetDevice
-  #define cudaStreamCreate hipStreamCreate
-  #define cudaSuccess hipSuccess
-#endif
-
 void Yolov4ObstacleDetector::LoadInputShape(
     const yolo::ModelParam &model_param) {
   float offset_ratio = model_param.offset_ratio();

--- a/modules/perception/camera/lib/obstacle/detector/yolov4/yolov4_obstacle_detector.h
+++ b/modules/perception/camera/lib/obstacle/detector/yolov4/yolov4_obstacle_detector.h
@@ -37,11 +37,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaStreamDestroy hipStreamDestroy
-  #define cudaStream_t hipStream_t
-#endif
-
 class Yolov4ObstacleDetector : public BaseObstacleDetector {
  public:
   Yolov4ObstacleDetector() : BaseObstacleDetector() {}

--- a/modules/perception/camera/lib/traffic_light/detector/detection/detection.cc
+++ b/modules/perception/camera/lib/traffic_light/detector/detection/detection.cc
@@ -32,12 +32,6 @@ namespace camera {
 
 using cyber::common::GetAbsolutePath;
 
-#if GPU_PLATFORM == AMD
-  #define cudaSetDevice hipSetDevice
-  #define cudaSuccess hipSuccess
-  #define cudaDeviceSynchronize hipDeviceSynchronize
-#endif
-
 bool TrafficLightDetection::Init(
     const camera::TrafficLightDetectorInitOptions &options) {
   std::string proto_path = GetAbsolutePath(options.root_dir, options.conf_file);

--- a/modules/perception/camera/lib/traffic_light/detector/recognition/classify.cc
+++ b/modules/perception/camera/lib/traffic_light/detector/recognition/classify.cc
@@ -28,12 +28,6 @@ namespace camera {
 
 using cyber::common::GetAbsolutePath;
 
-#if GPU_PLATFORM == AMD
-  #define cudaSetDevice hipSetDevice
-  #define cudaSuccess hipSuccess
-  #define cudaDeviceSynchronize hipDeviceSynchronize
-#endif
-
 void ClassifyBySimple::Init(
     const traffic_light::recognition::ClassifyParam& model_config,
     const int gpu_id, const std::string work_root) {

--- a/modules/perception/camera/test/camera_common_undistortion.cc
+++ b/modules/perception/camera/test/camera_common_undistortion.cc
@@ -25,14 +25,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaMalloc hipMalloc
-  #define cudaMemcpy hipMemcpy
-  #define cudaMemcpyHostToDevice hipMemcpyHostToDevice
-  #define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
-  #define cudaFree hipFree
-#endif
-
 /* Initialization of the GPU routines for camera data preprocessing
  *
  * Return: 0 - success; other - failure

--- a/modules/perception/camera/test/camera_common_undistortion.h
+++ b/modules/perception/camera/test/camera_common_undistortion.h
@@ -24,10 +24,6 @@ namespace apollo {
 namespace perception {
 namespace camera {
 
-#if GPU_PLATFORM == AMD
-  #define cudaSetDevice hipSetDevice
-#endif
-
 class ImageGpuPreprocessHandler {
  public:
   ImageGpuPreprocessHandler() {}


### PR DESCRIPTION
[Reason] All the needed hipification is already presented in the common header file `perception\base\common.h`