### PR TITLE
[HIPIFY][build] Introduction of GPU_PLATFORM = {AMD|NVIDIA} in the build system

### DIFF
--- a/tools/bazel.rc
+++ b/tools/bazel.rc
@@ -58,6 +58,20 @@ build:optimize --host_copt=-march=native
 build:cpu --verbose_failures
 build:gpu --define USE_GPU=true
 build:gpu --cxxopt="-DUSE_GPU=1"
+build:gpu --cxxopt="-DNVIDIA=0"
+build:gpu --cxxopt="-DAMD=1"
+
+# GPU platform
+build:amd --define USE_GPU=true
+build:amd --cxxopt="-DUSE_GPU=1"
+build:amd --cxxopt="-DNVIDIA=0"
+build:amd --cxxopt="-DAMD=1"
+build:amd --cxxopt="-DGPU_PLATFORM=AMD"
+build:nvidia --define USE_GPU=true
+build:nvidia --cxxopt="-DUSE_GPU=1"
+build:nvidia --cxxopt="-DNVIDIA=0"
+build:nvidia --cxxopt="-DAMD=1"
+build:nvidia --cxxopt="-DGPU_PLATFORM=NVIDIA"
 
 # Build with profiling
 build:prof --linkopt=-lprofiler


### PR DESCRIPTION
+ By default, Apollo should be building for NVIDIA as it is so now
  (because `NVIDIA` is unset and equals **0**, `GPU_PLATFORM` is also unset and equals 0 or **NVIDIA**)
+ If `--config=gpu`, Apollo should be building for NVIDIA as it is so now
  (because `NVIDIA` is set to **0**, `AMD` is set to **1**, `GPU_PLATFORM` is unset and equals 0 or **NVIDIA**)
+ If `--config=nvidia`, Apollo should be building for NVIDIA as it is so now
  (because `NVIDIA` is set to **0**, `AMD` is set to **1**, `GPU_PLATFORM` is set to **NVIDIA**)
+ If `--config=amd`, Apollo should be building for AMD
  (because `NVIDIA` is set to **0**, `AMD` is set to **1**, `GPU_PLATFORM` is set to **AMD**)