### PR TITLE
[HIPIFY][perception][inference][refactor] Remove/move hipification code

### DIFF
--- a/modules/perception/base/common.h
+++ b/modules/perception/base/common.h
@@ -22,9 +22,11 @@
   #if GPU_PLATFORM == NVIDIA
     #include <cublas_v2.h>
     #include <cuda_runtime.h>
+    #include <cuda_runtime_api.h>
   #elif GPU_PLATFORM == AMD
     #include <hipblas.h>
     #include <hip/hip_runtime.h>
+    #include <hip/hip_runtime_api.h>
     #define cublasCreate hipblasCreate
     #define cublasDestroy hipblasDestroy
     #define cublasHandle_t hipblasHandle_t

--- a/modules/perception/inference/tensorrt/entropy_calibrator.cc
+++ b/modules/perception/inference/tensorrt/entropy_calibrator.cc
@@ -14,19 +14,10 @@
  * limitations under the License.
  *****************************************************************************/
 #include "modules/perception/inference/tensorrt/entropy_calibrator.h"
+#include "modules/perception/base/common.h"
 
 #include <algorithm>
 #include <fstream>
-
-#if GPU_PLATFORM == NVIDIA
-  #include <cuda_runtime_api.h>
-#elif GPU_PLATFORM == AMD
-  #include <hip/hip_runtime_api.h>
-  #define cudaMalloc hipMalloc
-  #define cudaFree hipFree
-  #define cudaMemcpy hipMemcpy
-  #define cudaMemcpyHostToDevice hipMemcpyHostToDevice
-#endif
 
 namespace nvinfer1 {
 Int8EntropyCalibrator::Int8EntropyCalibrator(

--- a/modules/perception/inference/utils/cuda_util.cu
+++ b/modules/perception/inference/utils/cuda_util.cu
@@ -16,11 +16,6 @@
 
 #include "modules/perception/inference/utils/cuda_util.h"
 
-#if GPU_PLATFORM == NVIDIA
-  #include <cuda_runtime_api.h>
-#elif GPU_PLATFORM == AMD
-  #include <hip/hip_runtime_api.h>
-#endif
 #include <boost/thread.hpp>
 
 #include "cyber/common/log.h"
@@ -28,13 +23,6 @@
 namespace apollo {
 namespace perception {
 namespace inference {
-
-#if GPU_PLATFORM == AMD
-  #define cudaGetDevice hipGetDevice
-  #define cudaGetErrorString hipGetErrorString
-  #define cudaSetDevice hipSetDevice
-  #define cudaSuccess hipSuccess
-#endif
 
 static boost::thread_specific_ptr<CudaUtil> thread_instance_;
 

--- a/modules/perception/inference/utils/cuda_util.h
+++ b/modules/perception/inference/utils/cuda_util.h
@@ -18,8 +18,10 @@
 
 #if GPU_PLATFORM == NVIDIA
   #include <cublas_v2.h>
+  #include <cuda_runtime_api.h>
 #elif GPU_PLATFORM == AMD
   #include <hipblas.h>
+  #include <hip/hip_runtime_api.h>
 #endif
 
 namespace apollo {
@@ -31,11 +33,15 @@ namespace inference {
   #define cublasCreate hipblasCreate
   #define cublasDestroy hipblasDestroy
   #define cublasHandle_t hipblasHandle_t
-  #define cublasStatus_t hipblasStatus_t
-  #define cublasOperation_t hipblasOperation_t
   #define CUBLAS_OP_N HIPBLAS_OP_N
   #define CUBLAS_OP_T HIPBLAS_OP_T
+  #define cublasOperation_t hipblasOperation_t
   #define cublasSgemm hipblasSgemm
+  #define cublasStatus_t hipblasStatus_t
+  #define cudaGetDevice hipGetDevice
+  #define cudaGetErrorString hipGetErrorString
+  #define cudaSetDevice hipSetDevice
+  #define cudaSuccess hipSuccess
 #endif
 
 class CudaUtil {


### PR DESCRIPTION
[Reason] All the needed hipification is already presented or just added in the common header files `perception\base\common.h` and `modules\perception\inference\utils\cuda_util.h`

+ [fix] In `modules\perception\inference\tensorrt\entropy_calibrator.cc` include to the `perception\base\common.h` was added, because it occurred that it is a single file in the `inference` submodule without the inclusion of any common header file.