### PR TITLE
[HIPIFY][perception][inference][tensorrt] MIOpen support for cuDNN API

### DIFF
--- a/modules/perception/inference/tensorrt/rt_common.h
+++ b/modules/perception/inference/tensorrt/rt_common.h
@@ -22,7 +22,22 @@
 
 #include "NvCaffeParser.h"
 #include "NvInfer.h"
-#include <cudnn.h>
+#if GPU_PLATFORM == NVIDIA
+  #include <cudnn.h>
+#elif GPU_PLATFORM == AMD
+  #include <miopen.h>
+  #define CUDNN_DATA_FLOAT miopenFloat
+  #define CUDNN_SOFTMAX_ACCURATE MIOPEN_SOFTMAX_ACCURATE
+  #define CUDNN_SOFTMAX_MODE_CHANNEL MIOPEN_SOFTMAX_MODE_CHANNEL
+  #define cudnnCreate miopenCreate
+  #define cudnnCreateTensorDescriptor miopenCreateTensorDescriptor
+  #define cudnnDestroy miopenDestroy
+  #define cudnnDestroyTensorDescriptor miopenDestroyTensorDescriptor
+  #define cudnnHandle_t miopenHandle_t
+  #define cudnnSetStream miopenSetStream
+  #define cudnnSoftmaxForward miopenSoftmaxForward
+  #define cudnnTensorDescriptor_t miopenTensorDescriptor_t
+#endif
 
 #include "modules/perception/proto/rt.pb.h"
 


### PR DESCRIPTION
+ `modules\perception\inference\tensorrt\rt_common.h` is a common file for cuDNN/MIOpen
+ There are no other `APOLLO` codes using `cuDNN API` except [softmax_plugin.h](https://github.com/ApolloAuto/apollo/blob/master/modules/perception/inference/tensorrt/plugins/softmax_plugin.h) and [softmax_plugin.cu](https://github.com/ApolloAuto/apollo/blob/master/modules/perception/inference/tensorrt/plugins/softmax_plugin.cu)
+ There is a single `cuDNN API` `cudnnSetTensor4dDescriptorEx` unsupported by `MIOpen` which is used twice in [softmax_plugin.cu](https://github.com/ApolloAuto/apollo/blob/266afbf68d83fa6fac7a812ff8a950223f5ab2c0/modules/perception/inference/tensorrt/plugins/softmax_plugin.cu#L39) - the corresponding issue is filed to `MIOpen`:
[[#1430](https://github.com/ROCmSoftwarePlatform/MIOpen/issues/1430)][cuDNN] `cudnnSetTensor4dDescriptorEx` support in `MIOpen` is needed