### PR TITLE
[HIPIFY][perception][lidar][refactor] Remove/move hipification code

### DIFF
--- a/modules/perception/lidar/lib/detector/mask_pillars_detection/mask_pillars_detection.cc
+++ b/modules/perception/lidar/lib/detector/mask_pillars_detection/mask_pillars_detection.cc
@@ -19,12 +19,6 @@
 #include <numeric>
 #include <random>
 
-#if GPU_PLATFORM == NVIDIA
-  #include <cuda_runtime_api.h>
-#elif GPU_PLATFORM == AMD
-  #include <hip/hip_runtime_api.h>
-#endif
-
 #include "cyber/common/log.h"
 #include "modules/perception/base/object_pool_types.h"
 #include "modules/perception/base/point_cloud_util.h"
@@ -36,11 +30,6 @@
 namespace apollo {
 namespace perception {
 namespace lidar {
-
-#if GPU_PLATFORM == AMD
-  #define cudaSetDevice hipSetDevice
-  #define cudaSuccess hipSuccess
-#endif
 
 using base::Object;
 using base::PointD;

--- a/modules/perception/lidar/lib/detector/point_pillars_detection/common.h
+++ b/modules/perception/lidar/lib/detector/point_pillars_detection/common.h
@@ -48,19 +48,20 @@
 #elif GPU_PLATFORM == AMD
   #include <hip/hip_runtime_api.h>
   #define cudaError_t hipError_t
-  #define cudaSuccess hipSuccess
+  #define cudaFree hipFree
   #define cudaGetErrorString hipGetErrorString
   #define cudaMalloc hipMalloc
-  #define cudaFree hipFree
-  #define cudaMemset hipMemset
   #define cudaMemcpy hipMemcpy
   #define cudaMemcpyAsync hipMemcpyAsync
   #define cudaMemcpyDeviceToDevice hipMemcpyDeviceToDevice
   #define cudaMemcpyDeviceToHost hipMemcpyDeviceToHost
   #define cudaMemcpyHostToDevice hipMemcpyHostToDevice
+  #define cudaMemset hipMemset
+  #define cudaSetDevice hipSetDevice
   #define cudaStream_t hipStream_t
   #define cudaStreamCreate hipStreamCreate
   #define cudaStreamDestroy hipStreamDestroy
+  #define cudaSuccess hipSuccess
 #endif
 
 namespace apollo {

--- a/modules/perception/lidar/lib/detector/point_pillars_detection/point_pillars_detection.cc
+++ b/modules/perception/lidar/lib/detector/point_pillars_detection/point_pillars_detection.cc
@@ -19,14 +19,6 @@
 #include <numeric>
 #include <random>
 
-#if GPU_PLATFORM == NVIDIA
-  #include <cuda_runtime_api.h>
-#elif GPU_PLATFORM == AMD
-  #include <hip/hip_runtime_api.h>
-  #define cudaSetDevice hipSetDevice
-  #define cudaSuccess hipSuccess
-#endif
-
 #include "cyber/common/log.h"
 #include "modules/perception/base/object_pool_types.h"
 #include "modules/perception/base/point_cloud_util.h"


### PR DESCRIPTION
[Reason] All the needed hipification is already presented or just added in the common header file `modules\perception\lidar\lib\detector\point_pillars_detection\common.h`